### PR TITLE
Create workflow to manage stale issues

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -22,7 +22,7 @@ jobs:
       with:
         days-before-issue-stale: 7
         days-before-close: 3
-        stale-issue-message: 'This issue is stale because it has been open 7 days with no activity. Remove stale label or comment or this will be closed in 3 days.'
+        stale-issue-message: 'This issue is stale due to 7 days of inactivity. Comment or remove the stale label to keep it open. Otherwise, it will be closed in 3 days.'
         stale-issue-label: 'inactive'
         any-of-labels: 'needs-more-info'
   

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,28 @@
+# This workflow warns and then closes issues and PRs that have had no activity for a specified amount of time.
+#
+# You can adjust the behavior by modifying this file.
+# For more information, see:
+# https://github.com/actions/stale
+name: Mark stale issues and pull requests
+
+on:
+  schedule:
+  - cron: '30 8 * * *'
+
+jobs:
+  stale:
+
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+
+    steps:
+    - uses: actions/stale@v9
+      with:
+        days-before-issue-stale: 7
+        days-before-close: 3
+        stale-issue-message: 'This issue is stale because it has been open 7 days with no activity. Remove stale label or comment or this will be closed in 3 days.'
+        stale-issue-label: 'inactive'
+        any-of-labels: 'needs-more-info'
+  


### PR DESCRIPTION
this runs daily. 
after marked `needs-more-info`, 7 days to stale, and 3 days to close.