### PR TITLE
update bug template to display how to get log file

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -17,7 +17,7 @@ https://github.com/microsoft/copilot-intellij-feedback/wiki/Enable-debug-logging
 Get log file:
 via Help -> Show Log in Explorer | Finder -> attach idea.log
 -->
-- Debug-level Log Files:
+- Debug-level Log Files([How-to](https://github.com/microsoft/copilot-intellij-feedback/wiki/Enable-debug-logging#log-file)):
 
 Steps to Reproduce:
 


### PR DESCRIPTION
Benefits:

1. if user failed to notice the guide at bug creation, it provides additional chance for them to attach one. 
2. it provides the triage team convenience to copy and paste the guide, when requesting logs.