### PR TITLE
feat: add issue management policies

### DIFF
--- a/.github/policies/issueCommentManagement.yml
+++ b/.github/policies/issueCommentManagement.yml
@@ -1,0 +1,34 @@
+id: issueCommentManagement.issueCommentOpened
+name: GitOps.issueCommentManagement
+description: Handlers for when an issue comment is first opened
+owner:
+resource: repository
+disabled: false
+where:
+configuration:
+  resourceManagementConfiguration:
+    eventResponderTasks:
+      - description: "[Issue Management] Add needs attention label to issue if there is a new comment by a non-member"
+        if:
+          - payloadType: Issue_Comment
+          - and:
+            - isOpen
+            - isIssue
+            - not:
+                or:
+                  - hasLabel:
+                      label: needs attention
+                  - activitySenderHasAssociation:
+                      association: Member
+                  - isActivitySender:
+                      user: msftbot[bot]
+                      issueAuthor: False
+                  - isActivitySender:
+                      user: microsoft-github-policy-service[bot]
+                      issueAuthor: False
+                  - isActivitySender:
+                      user: github-actions[bot]
+                      issueAuthor: False
+        then:
+          - addLabel:
+              label: needs attention

--- a/.github/policies/resourceManagement.yml
+++ b/.github/policies/resourceManagement.yml
@@ -1,0 +1,82 @@
+id: 
+name: GitOps.PullRequestIssueManagement
+description: GitOps.PullRequestIssueManagement primitive
+owner: 
+resource: repository
+disabled: false
+where: 
+configuration:
+  resourceManagementConfiguration:
+    eventResponderTasks:
+    - description: "[Issue Greeting] Add needs attention label when issue opened"
+      if:
+      - payloadType: Issues
+      - isAction:
+          action: Opened
+      then:
+    #   - addReply:
+        #   reply: Thank you for contacting us! Any issue or feedback from you is quite important to us. We will do our best to fully respond to your issue as soon as possible. Sometimes additional investigations may be needed, we will usually get back to you within 2 days by adding comments to this issue. Please stay tuned.
+      - addLabel:
+          label: needs attention
+    - description: "[Idle Issue Management] Remove no recent activity label from issues"
+      if:
+      - payloadType: Issues
+      - hasLabel:
+          label: no recent activity
+      - not:
+          isAction:
+            action: Closed
+      then:
+      - removeLabel:
+          label: no recent activity
+    - description: "[Idle Issue Management] Remove no recent activity label when an issue is commented on"
+      if:
+      - payloadType: Issue_Comment
+      - hasLabel:
+          label: no recent activity
+      then:
+      - removeLabel:
+          label: no recent activity
+    - description: "[Idle Issue Management] Replace needs more info label with needs attention label when a non-member comment created on an issue"
+      if:
+      - payloadType: Issue_Comment
+      - isOpen
+      - hasLabel:
+          label: needs more info
+      - isAction:
+          action: Created
+      - not:
+          or:
+            - activitySenderHasAssociation:
+                association: Member
+            - isActivitySender:
+                user: msftbot[bot]
+                issueAuthor: False
+            - isActivitySender:
+                user: microsoft-github-policy-service[bot]
+                issueAuthor: False
+            - isActivitySender:
+                user: github-actions[bot]
+                issueAuthor: False
+      then:
+      - removeLabel:
+          label: needs more info
+      - addLabel:
+          label: needs attention
+    - description: "[Issue Management] Remove close-wait label"
+      if:
+      - payloadType: Issues
+      - hasLabel:
+          label: close-wait
+      - not:
+          isActivitySender:
+            user: github-actions[bot]
+            issueAuthor: False
+      - not:
+          isAction:
+            action: Closed
+      then:
+      - removeLabel:
+          label: close-wait
+onFailure: 
+onSuccess: 

--- a/.github/policies/scheduler.yml
+++ b/.github/policies/scheduler.yml
@@ -1,0 +1,171 @@
+id: 
+name: GitOps.PullRequestIssueManagement
+description: GitOps.Schedule.PullRequestIssueManagement
+owner: 
+resource: repository
+disabled: false
+where: 
+configuration:
+  resourceManagementConfiguration:
+    scheduledSearches:
+    - description: "[Idle Issue Management] Add no recent activity label to issues without bug/feature-request label"
+      frequencies:
+      - weekday:
+          day: Monday
+          time: 0:0
+      - weekday:
+          day: Tuesday
+          time: 0:0
+      - weekday:
+          day: Wednesday
+          time: 0:0
+      - weekday:
+          day: Thursday
+          time: 0:0
+      - weekday:
+          day: Friday
+          time: 0:0
+      filters:
+      - isIssue
+      - isOpen
+      - hasLabel:
+          label: needs more info
+      - isNotLabeledWith:
+          label: no recent activity
+      - isNotLabeledWith:
+          label: bug
+      - isNotLabeledWith:
+          label: feature-request
+      - noActivitySince:
+          days: 7
+      actions:
+      - addLabel:
+          label: no recent activity
+      - addReply:
+          reply: >
+            This issue has been automatically marked as stale because it has been marked as requiring author feedback but has not had any activity for **7 days**. It will be closed if no further activity occurs **within 3 days of this comment**. If it *is* closed, feel free to comment when you are able to provide the additional information and we will re-investigate.
+    - description: "[Idle Issue Management] Close stale issues"
+      frequencies:
+      - weekday:
+          day: Monday
+          time: 0:0
+      - weekday:
+          day: Tuesday
+          time: 0:0
+      - weekday:
+          day: Wednesday
+          time: 0:0
+      - weekday:
+          day: Thursday
+          time: 0:0
+      - weekday:
+          day: Friday
+          time: 0:0
+      filters:
+      - isOpen
+      - isIssue
+      - noActivitySince:
+          days: 3
+      - hasLabel:
+          label: no recent activity
+      - hasLabel:
+          label: needs more info
+      - isNotInAnyMilestone
+      - isNotLabeledWith:
+          label: bug
+      - isNotLabeledWith:
+          label: feature-request
+      actions:
+      - closeIssue
+      - addReply:
+          reply: 'Due to lack of details for further investigation, we will archive the issue for now. In case you still have following-up questions on this issue, please always feel free to reopen the issue by clicking ‘reopen issue’ button below the comment box. We will get back to you as soon as possible. '
+    - description: "[Idle Issue Management] Add no recent activity label to issues with bug label"
+      frequencies:
+      - weekday:
+          day: Monday
+          time: 0:0
+      - weekday:
+          day: Tuesday
+          time: 0:0
+      - weekday:
+          day: Wednesday
+          time: 0:0
+      - weekday:
+          day: Thursday
+          time: 0:0
+      - weekday:
+          day: Friday
+          time: 0:0
+      filters:
+      - isIssue
+      - isOpen
+      - hasLabel:
+          label: needs more info
+      - hasLabel:
+          label: bug
+      - isNotLabeledWith:
+          label: no recent activity
+      - noActivitySince:
+          days: 7
+      actions:
+      - addLabel:
+          label: no recent activity
+      - addReply:
+          reply: >
+            This issue has been automatically marked as stale because it has been marked as requiring author feedback but has not had any activity for **7 days**. As it is labeled with bug, it will be manually handled
+    - description: "[Idle Issue Management] Add no recent activity label to issues with feature-request label"
+      frequencies:
+      - weekday:
+          day: Monday
+          time: 0:0
+      - weekday:
+          day: Tuesday
+          time: 0:0
+      - weekday:
+          day: Wednesday
+          time: 0:0
+      - weekday:
+          day: Thursday
+          time: 0:0
+      - weekday:
+          day: Friday
+          time: 0:0
+      filters:
+      - isIssue
+      - isOpen
+      - hasLabel:
+          label: needs more info
+      - hasLabel:
+          label: feature-request
+      - isNotLabeledWith:
+          label: no recent activity
+      - noActivitySince:
+          days: 7
+      actions:
+      - addLabel:
+          label: no recent activity
+      - addReply:
+          reply: >
+            This issue has been automatically marked as stale because it has been marked as requiring author feedback but has not had any activity for **7 days**. As it is labeled with feature-request, it will be manually handled
+    - description: "[Close Issue Management] For issue with close-wait label"
+      frequencies:
+      - daily:
+          time: 1:0
+      filters:
+      - isOpen
+      - isIssue
+      - noActivitySince:
+          days: 1
+      - hasLabel:
+          label: close-wait
+      - isNotLabeledWith:
+          label: bug
+      - isNotLabeledWith:
+          label: feature-request
+      - isNotInAnyMilestone
+      actions:
+      - closeIssue
+      - removeLabel:
+          label: close-wait
+onFailure: 
+onSuccess: 


### PR DESCRIPTION
The [microsoft-github-policy-service](https://github.com/apps/microsoft-github-policy-service) will follow the policies to tag issues. Some common scenarios:
1. Add 'needs attention' label for issues that need our reply
2. Auto close inactive issues