### PR TITLE
feat: remove needs attention automatically and add needs log label with auto reply

### DIFF
--- a/.github/policies/issueCommentManagement.yml
+++ b/.github/policies/issueCommentManagement.yml
@@ -32,3 +32,16 @@ configuration:
         then:
           - addLabel:
               label: needs attention
+      - description: "[Issue Management] Remove needs attention label if there is a new comment by a member"
+        if:
+          - payloadType: Issue_Comment
+          - and:
+            - isOpen
+            - isIssue
+            - hasLabel:
+                label: needs attention
+            - activitySenderHasAssociation:
+                association: Member
+        then:
+          - removeLabel:
+              label: needs attention

--- a/.github/policies/resourceManagement.yml
+++ b/.github/policies/resourceManagement.yml
@@ -78,5 +78,21 @@ configuration:
       then:
       - removeLabel:
           label: close-wait
+    - description: "[Issue Management] Add log collection message when needs log label is added"
+      if:
+      - payloadType: Issues
+      - labelAdded:
+          label: needs log
+      then:
+      - addReply:
+          reply: |
+            Hi! We need debug logs to help investigate this issue further.
+            
+            Please follow the instructions in our documentation to enable debug logging and collect the logs:
+            **[Enable debug logging guide](https://github.com/microsoft/copilot-intellij-feedback/wiki/Enable-debug-logging)**
+            
+            Once you have the logs, please attach them to this issue or share them in a comment. This will help us diagnose and resolve the issue more quickly.
+            
+            Thank you for your patience!
 onFailure: 
 onSuccess: 

--- a/.github/policies/scheduler.yml
+++ b/.github/policies/scheduler.yml
@@ -28,8 +28,13 @@ configuration:
       filters:
       - isIssue
       - isOpen
-      - hasLabel:
-          label: needs more info
+      - or:
+        - hasLabel:
+            label: needs more info
+        - hasLabel:
+            label: needs log
+      - isNotLabeledWith:
+          label: needs attention
       - isNotLabeledWith:
           label: no recent activity
       - isNotLabeledWith:
@@ -68,8 +73,13 @@ configuration:
           days: 3
       - hasLabel:
           label: no recent activity
-      - hasLabel:
-          label: needs more info
+      - or:
+        - hasLabel:
+            label: needs more info
+        - hasLabel:
+            label: needs log
+      - isNotLabeledWith:
+          label: needs attention
       - isNotInAnyMilestone
       - isNotLabeledWith:
           label: bug
@@ -99,10 +109,15 @@ configuration:
       filters:
       - isIssue
       - isOpen
-      - hasLabel:
-          label: needs more info
+      - or:
+        - hasLabel:
+            label: needs more info
+        - hasLabel:
+            label: needs log
       - hasLabel:
           label: bug
+      - isNotLabeledWith:
+          label: needs attention
       - isNotLabeledWith:
           label: no recent activity
       - noActivitySince:
@@ -133,10 +148,15 @@ configuration:
       filters:
       - isIssue
       - isOpen
-      - hasLabel:
-          label: needs more info
+      - or:
+        - hasLabel:
+            label: needs more info
+        - hasLabel:
+            label: needs log
       - hasLabel:
           label: feature-request
+      - isNotLabeledWith:
+          label: needs attention
       - isNotLabeledWith:
           label: no recent activity
       - noActivitySince:


### PR DESCRIPTION
1. Remove `needs attention` automatically when a member adds comment
2. Add `needs log` label support, and automatically provide log collection instructions when this label is added