### PR TITLE
fix: admin should be considered as member

### DIFF
--- a/.github/policies/issueCommentManagement.yml
+++ b/.github/policies/issueCommentManagement.yml
@@ -20,6 +20,8 @@ configuration:
                       label: needs attention
                   - activitySenderHasPermission:
                       permission: write
+                  - activitySenderHasPermission:
+                      permission: admin
                   - isActivitySender:
                       user: msftbot[bot]
                       issueAuthor: False
@@ -40,8 +42,11 @@ configuration:
             - isIssue
             - hasLabel:
                 label: needs attention
-            - activitySenderHasPermission:
-                permission: write
+            - or:
+              - activitySenderHasPermission:
+                  permission: write
+              - activitySenderHasPermission:
+                  permission: admin
         then:
           - removeLabel:
               label: needs attention

--- a/.github/policies/issueCommentManagement.yml
+++ b/.github/policies/issueCommentManagement.yml
@@ -43,10 +43,10 @@ configuration:
             - hasLabel:
                 label: needs attention
             - or:
-              - activitySenderHasPermission:
-                  permission: write
-              - activitySenderHasPermission:
-                  permission: admin
+                - activitySenderHasPermission:
+                    permission: write
+                - activitySenderHasPermission:
+                    permission: admin
         then:
           - removeLabel:
               label: needs attention

--- a/.github/policies/resourceManagement.yml
+++ b/.github/policies/resourceManagement.yml
@@ -49,6 +49,8 @@ configuration:
           or:
             - activitySenderHasPermission:
                 permission: write
+            - activitySenderHasPermission:
+                permission: admin
             - isActivitySender:
                 user: msftbot[bot]
                 issueAuthor: False


### PR DESCRIPTION
Though admin also has write permission, the GitHub Policy bot does not think admins have write permission and treats them as non member. Add condition for admin explicitly to workaround this issue in the bot.